### PR TITLE
Mitigate: checks created on wrong check suites

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5582,10 +5582,10 @@ class Conflibot {
         return __awaiter(this, void 0, void 0, function* () {
             const refs = yield this.octokit.checks.listForRef(Object.assign(Object.assign({}, github.context.repo), { ref: github.context.payload.pull_request
                     .head.sha }));
-            const current = refs.data.check_runs.find((check) => check.name == "conflibot");
+            const current = refs.data.check_runs.find((check) => check.name == "conflibot/details");
             core.debug(`checks: ${JSON.stringify(refs.data)}`);
             core.debug(`current check: ${JSON.stringify(current)}`);
-            const params = Object.assign(Object.assign({}, github.context.repo), { name: "conflibot", head_sha: github.context.payload
+            const params = Object.assign(Object.assign({}, github.context.repo), { name: "conflibot/details", head_sha: github.context.payload
                     .pull_request.head.sha, status: (conclusion ? "completed" : "in_progress"), conclusion,
                 output });
             if (current) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -5581,8 +5581,8 @@ class Conflibot {
     setStatus(conclusion = undefined, output = undefined) {
         return __awaiter(this, void 0, void 0, function* () {
             const refs = yield this.octokit.checks.listForRef(Object.assign(Object.assign({}, github.context.repo), { ref: github.context.ref }));
-            const current = refs.data.check_runs.find((check) => check.name == "details");
-            const params = Object.assign(Object.assign({}, github.context.repo), { name: "details", head_sha: github.context.payload
+            const current = refs.data.check_runs.find((check) => check.name == "conflibot");
+            const params = Object.assign(Object.assign({}, github.context.repo), { name: "conflibot", head_sha: github.context.payload
                     .pull_request.head.sha, status: (conclusion ? "completed" : "in_progress"), conclusion,
                 output });
             if (current) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -5582,6 +5582,8 @@ class Conflibot {
         return __awaiter(this, void 0, void 0, function* () {
             const refs = yield this.octokit.checks.listForRef(Object.assign(Object.assign({}, github.context.repo), { ref: github.context.ref }));
             const current = refs.data.check_runs.find((check) => check.name == "conflibot");
+            core.debug(`checks: ${JSON.stringify(refs.data)}`);
+            core.debug(`current check: ${JSON.stringify(current)}`);
             const params = Object.assign(Object.assign({}, github.context.repo), { name: "conflibot", head_sha: github.context.payload
                     .pull_request.head.sha, status: (conclusion ? "completed" : "in_progress"), conclusion,
                 output });

--- a/dist/index.js
+++ b/dist/index.js
@@ -5580,7 +5580,8 @@ class Conflibot {
     }
     setStatus(conclusion = undefined, output = undefined) {
         return __awaiter(this, void 0, void 0, function* () {
-            const refs = yield this.octokit.checks.listForRef(Object.assign(Object.assign({}, github.context.repo), { ref: github.context.ref }));
+            const refs = yield this.octokit.checks.listForRef(Object.assign(Object.assign({}, github.context.repo), { ref: github.context.payload.pull_request
+                    .head.sha }));
             const current = refs.data.check_runs.find((check) => check.name == "conflibot");
             core.debug(`checks: ${JSON.stringify(refs.data)}`);
             core.debug(`current check: ${JSON.stringify(current)}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,8 @@ class Conflibot {
   > {
     const refs = await this.octokit.checks.listForRef({
       ...github.context.repo,
-      ref: github.context.ref,
+      ref: (github.context.payload.pull_request as Octokit.PullsGetResponse)
+        .head.sha,
     });
     const current = refs.data.check_runs.find(
       (check) => check.name == "conflibot"

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,8 @@ class Conflibot {
     const current = refs.data.check_runs.find(
       (check) => check.name == "conflibot"
     );
+    core.debug(`checks: ${JSON.stringify(refs.data)}`);
+    core.debug(`current check: ${JSON.stringify(current)}`);
 
     const params = {
       ...github.context.repo,

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,12 +33,12 @@ class Conflibot {
       ref: github.context.ref,
     });
     const current = refs.data.check_runs.find(
-      (check) => check.name == "details"
+      (check) => check.name == "conflibot"
     );
 
     const params = {
       ...github.context.repo,
-      name: "details",
+      name: "conflibot",
       head_sha: (github.context.payload
         .pull_request as Octokit.PullsGetResponse).head.sha,
       status: (conclusion ? "completed" : "in_progress") as

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,14 +34,14 @@ class Conflibot {
         .head.sha,
     });
     const current = refs.data.check_runs.find(
-      (check) => check.name == "conflibot"
+      (check) => check.name == "conflibot/details"
     );
     core.debug(`checks: ${JSON.stringify(refs.data)}`);
     core.debug(`current check: ${JSON.stringify(current)}`);
 
     const params = {
       ...github.context.repo,
-      name: "conflibot",
+      name: "conflibot/details",
       head_sha: (github.context.payload
         .pull_request as Octokit.PullsGetResponse).head.sha,
       status: (conclusion ? "completed" : "in_progress") as


### PR DESCRIPTION
When multiple workflows are run by GitHub Actions, apparently checks are sometimes created under the wrong check suite.
To mitigate this issue, make the name unique and easier to identify.

https://github.community/t5/GitHub-Actions/Github-Actions-Status-Checks-created-on-incorrect-Check-Suite-Id/m-p/37754

![Screen Shot 2020-04-12 at 4 31 14](https://user-images.githubusercontent.com/943695/79053784-c15a5b00-7c7a-11ea-893d-09751104f5bc.png)
