### PR TITLE
Open a PR to sync dist instead of pushing to master

### DIFF
--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -1,7 +1,5 @@
-# PRs are merged without a rebuilt dist; this rebuilds and commits it
-# right after each merge lands. Release tags must be cut after this
-# commit (verify-release.yml guards that). Pushes made with
-# GITHUB_TOKEN do not trigger workflows, so this cannot loop.
+# Sync dist via a PR, not a direct push: master requires the "test"
+# check, and only a PR (not a GITHUB_TOKEN push) triggers it.
 name: update-dist
 on:
   push:
@@ -10,12 +8,16 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency: update-dist
 
 jobs:
   update-dist:
     runs-on: ubuntu-slim
+    env:
+      GH_TOKEN: ${{ github.token }}
+      BRANCH: update-dist
     steps:
       - uses: actions/checkout@v7
         with:
@@ -28,7 +30,7 @@ jobs:
           npm install -g yarn
           yarn --frozen-lockfile
       - run: yarn package
-      - name: Commit the rebuilt dist if it changed
+      - name: Open or update a PR with the rebuilt dist
         run: |
           if git diff --quiet dist; then
             echo "dist is up to date"
@@ -36,6 +38,13 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
           git add dist
           git commit -m "chore: rebuild dist"
-          git push
+          # Replace any stale branch from an earlier unmerged run.
+          git push --force origin "$BRANCH"
+          if [ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
+            gh pr create --head "$BRANCH" --base master \
+              --title "chore: rebuild dist" \
+              --body "Rebuilt \`dist/\` to match master after the latest merge."
+          fi

--- a/README.md
+++ b/README.md
@@ -106,13 +106,14 @@ $ yarn package     # bundle dist/index.js with ncc
 Pull requests do not need to include a rebuilt `dist/`: CI bundles
 each PR's source and runs the test suite (including a smoke test of
 the bundle) against that build, and after the merge the `update-dist`
-workflow commits the rebuilt `dist/` to master. This also lets
-Renovate and Dependabot PRs merge automatically once CI is green.
+workflow opens a PR that syncs the rebuilt `dist/` to master. This
+also lets Renovate and Dependabot PRs merge automatically once CI is
+green.
 
-When cutting a release, tag only after the `update-dist` commit for
-your merge has landed; the `verify-release` workflow rebuilds the
-bundle for every `v*` tag and fails if the tagged `dist/` does not
-match its source.
+When cutting a release, tag only after the `update-dist` PR for your
+merge has landed; the `verify-release` workflow rebuilds the bundle
+for every `v*` tag and fails if the tagged `dist/` does not match its
+source.
 
 ## Screenshots
 


### PR DESCRIPTION
## Problem

The `update-dist` workflow pushed the rebuilt `dist/` straight to `master`, but `master` requires the `test` status check with **strict** mode. A push made with `GITHUB_TOKEN` starts no workflow, so `test` never ran on the pushed commit and branch protection rejected every push that carried a `dist` change — those commits were then fixed up by hand (e.g. `56be5c4 Update dist`).

## Fix

Open a PR from an `update-dist` branch instead of pushing to `master`. Creating/updating a PR is the [documented exception](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs) to `GITHUB_TOKEN` not triggering workflows, so the required `test` check runs and the PR can merge — **without** weakening branch protection or adding a PAT / GitHub App / deploy-key secret.

- Force-push the branch so a stale branch from an earlier unmerged run is replaced.
- Skip PR creation when one is already open (the force-push updates it).
- Add `pull-requests: write` (needed to open the PR).
- Update the `README` development notes to match.

## Note

The `test` run on a `GITHUB_TOKEN`-created PR may land in an approval-required state. If so it shows an "Approve and run" button rather than blocking outright; we'll confirm the actual behavior the next time a `dist` change flows through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)